### PR TITLE
Add guard clause as a conditional statement

### DIFF
--- a/guidelines/ruby.md
+++ b/guidelines/ruby.md
@@ -299,6 +299,32 @@ def valid?
 end
 ```
 
+* Avoid use of nested conditionals for flow of control
+
+Prefer a guard clause when you can assert invalid data. A guard clause is a conditional statement at the top of a function that bails out as soon as it can.
+
+```ruby
+# bad
+def compute_thing(thing)
+  if thing[:foo]
+    update_with_bar(thing[:foo])
+    if thing[:foo][:bar]
+      partial_compute(thing)
+    else
+      re_compute(thing)
+    end
+  end
+end
+
+# good
+def compute_thing(thing)
+  return unless thing[:foo]
+  update_with_bar(thing[:foo])
+  return re_compute(thing) unless thing[:foo][:bar]
+  partial_compute(thing)
+end
+```
+
 * Avoid `self` when not required
 
 ```ruby


### PR DESCRIPTION
Avoid use of nested conditionals for flow of control.

Prefer a guard clause when you can assert invalid data. A guard clause is a conditional statement at the top of a function that bails out as soon as it can.